### PR TITLE
SVC-20919: module hiera for settings should be empty hash

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,4 +6,4 @@ profile_hardening::remove_setuid_setgid::files:
   - "/usr/libexec/Xorg.wrap"
   - "/usr/sbin/login_duo"
 
-profile_hardening::sysctl::settings: []
+profile_hardening::sysctl::settings: {}


### PR DESCRIPTION
Fixing what Ben caught in https://github.com/ncsa/puppet-profile_hardening/pull/2 (that module Hiera for sysctl::settings: should be empty hash, not empty array).