### PR TITLE
SVCPLAN-2364: remove_setuid_setgid::files — add fusermount3

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,6 +1,7 @@
 ---
 profile_hardening::remove_setuid_setgid::files:
   - "/usr/bin/fusermount"
+  - "/usr/bin/fusermount3"
   - "/usr/bin/ksu"
   - "/usr/bin/nvidia-modprobe"
   - "/usr/libexec/Xorg.wrap"


### PR DESCRIPTION
Tested on mgtest01.