### PR TITLE
SVCPLAN-2865 Change remove_setuid_setgid::files lookup_options

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,10 @@
 ---
+lookup_options:
+  profile_hardening::remove_setuid_setgid::files:
+    merge:
+      strategy: "deep"
+      knockout_prefix: "--"
+
 profile_hardening::remove_setuid_setgid::files:
   - "/usr/bin/fusermount"
   - "/usr/bin/fusermount3"


### PR DESCRIPTION
Set lookup options on profile_hardening::remove_setuid_setgid::files: to merge

Updating to this version would only be an issue if you are overriding the default profile_hardening::remove_setuid_setgid::files to remove a file from the default list. If you need that functionality use the knockout_prefix like so: profile_hardening::remove_setuid_setgid::files:
  - "--/tmp/filename"   # File you DO want to be setuid/setgid